### PR TITLE
Add config variable in .env to disable webpack dev-server hot reload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ CONSOLE_PRINT=friendly
 # Open new browser tab when webpack dev-server is started
 DEV_SERVER_OPEN=true
 
+# Enable webpack dev-server hot reload
+DEV_SERVER_HOT_RELOAD=true
+
 # ------------------------------------------------------------------------------ AUTO GENERATED
 
 # AUTO GENERATED, do not touch.

--- a/config/webpack/webpack.development.js
+++ b/config/webpack/webpack.development.js
@@ -12,6 +12,7 @@ const config = require("../global.config");
 // test env
 const CONSOLE_PRINT_FRIENDLY = process.env.CONSOLE_PRINT === "friendly";
 const DEV_SERVER_OPEN = process.env.DEV_SERVER_OPEN === "true";
+const DEV_SERVER_HOT_RELOAD = process.env.DEV_SERVER_HOT_RELOAD === "true";
 const ENABLE_DEV_PROXY = process.env.ENABLE_DEV_PROXY === "true";
 
 // ----------------------------------------------------------------------------- CONFIG
@@ -137,11 +138,12 @@ const developmentConfig = {
   devServer: {
     contentBase: paths.dist,
     port: parseInt(process.env.DEV_SERVER_PORT) || 3000,
-    hot: true,
+    hot: DEV_SERVER_HOT_RELOAD,
     inline: true,
     compress: true,
     historyApiFallback: true,
-
+    // reload/refresh the page when file changes are detected
+    liveReload: DEV_SERVER_HOT_RELOAD,
     // open new browser tab when webpack dev-server is started
     open: DEV_SERVER_OPEN,
     // Write file to dist on each compile


### PR DESCRIPTION
It's useful to disable hot reload sometimes when using apps with webgl for instance.