### PR TITLE
Add babel precise browser support to fix syntax errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "current"
+          "node": "current",
+          "browsers": "> 0.25%, last 2 versions, not dead"
         }
       }
     ],


### PR DESCRIPTION
Add precise browser support to fix some syntax errors browsers can have on last 1 and 2 versions.

Example : import EnvUtils on Safari desktop 14.0.3 cause syntax error.